### PR TITLE
fix(auth): temporarily disable secure cookie flag for testing

### DIFF
--- a/src/redux/features/auth.slice.ts
+++ b/src/redux/features/auth.slice.ts
@@ -30,7 +30,9 @@ const authSlice = createSlice({
         expires: 7, // 7 days
         path: "/",  // Available across all paths
         sameSite: "lax", // Less strict than 'strict' for better compatibility
-        secure: process.env.NODE_ENV === "production" // Only use HTTPS in production
+        // TODO: Set secure to true in production
+        secure: false, // process.env.NODE_ENV === "production" // Only use HTTPS in production
+        httpOnly: false, // Accessible only through HTTP(S)
       });
     },
     logOut: (state) => {


### PR DESCRIPTION
The secure flag for cookies was temporarily disabled to facilitate testing in non-production environments. This change is marked with a TODO to ensure it is reverted for production use. Additionally, the httpOnly flag was added to control cookie accessibility.